### PR TITLE
Change genbkbasr into genbkbasr-regular of available fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Available fonts:
 * genbkbasb
 * genbkbasbi
 * genbkbasi
-* genbkbasr
+* genbkbasr-regular
 
 Locale-optimised font sets can be served by specifying the locale in the fonts.css URL.
 ```html


### PR DESCRIPTION
Its exposed as `"genbkbasr-regular"` in index.js but listed as `genbkbasr` in the README.md